### PR TITLE
Update numcombine

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = stsci.image
-version = 2.2.0.dev
+version = 2.3.0
 author = Todd Miller
 author-email = help@stsci.edu
 summary = Image array manipulation functions

--- a/stsci/image/combine.py
+++ b/stsci/image/combine.py
@@ -1,12 +1,13 @@
-from __future__ import division, print_function
+from __future__ import (absolute_import, division, unicode_literals,
+                        print_function)
 
-import numpy as num
+import numpy as np
 from ._combine import combine as _combine
 
 
 def _combine_f(funcstr, arrays, output=None, outtype=None, nlow=0, nhigh=0,
                badmasks=None):
-    arrays = [ num.asarray(a) for a in arrays ]
+    arrays = [ np.asarray(a) for a in arrays ]
     shape = arrays[0].shape
     if output is None:
         if outtype is not None:
@@ -43,41 +44,41 @@ def imedian(arrays, output=None, outtype=None, nlow=0, nhigh=0, badmasks=None):
     nlow : int
         The number of pixels to be excluded from median on the low end of the pixel stack.
 
-    nhigh : int 
+    nhigh : int
         The number of pixels to be excluded from median on the high end of the pixel stack.
 
-    badmasks : list of ndarrays 
+    badmasks : list of ndarrays
         Boolean arrays corresponding to 'arrays', where true
                indicates that a particular pixel is not to be included in the
                median calculation.
 
     Examples
     ---------
-    >>> a = num.arange(4)
+    >>> a = np.arange(4)
     >>> a = a.reshape((2,2))
     >>> arrays = [a*16, a*4, a*2, a*8]
     >>> median(arrays)
     array([[ 0,  6],
            [12, 18]])
-           
+
     >>> median(arrays, nhigh=1)
     array([[ 0,  4],
            [ 8, 12]])
-           
+
     >>> median(arrays, nlow=1)
     array([[ 0,  8],
            [16, 24]])
-           
-    >>> median(arrays, outtype=num.float32)
+
+    >>> median(arrays, outtype=np.float32)
     array([[  0.,   6.],
            [ 12.,  18.]], dtype=float32)
-           
-    >>> bm = num.zeros((4,2,2), dtype=num.bool8)
+
+    >>> bm = np.zeros((4,2,2), dtype=np.bool8)
     >>> bm[2,...] = 1
     >>> median(arrays, badmasks=bm)
     array([[ 0,  8],
            [16, 24]])
-           
+
     >>> median(arrays, badmasks=threshhold(arrays, high=25))
     array([[ 0,  6],
            [ 8, 12]])
@@ -109,7 +110,7 @@ def median(arrays, output=None, outtype=None, nlow=0, nhigh=0, badmasks=None):
                indicates that a particular pixel is not to be included in the
                median calculation.
 
-    >>> a = num.arange(4)
+    >>> a = np.arange(4)
     >>> a = a.reshape((2,2))
     >>> arrays = [a*16, a*4, a*2, a*8]
     >>> median(arrays)
@@ -121,10 +122,10 @@ def median(arrays, output=None, outtype=None, nlow=0, nhigh=0, badmasks=None):
     >>> median(arrays, nlow=1)
     array([[ 0,  8],
            [16, 24]])
-    >>> median(arrays, outtype=num.float32)
+    >>> median(arrays, outtype=np.float32)
     array([[  0.,   6.],
            [ 12.,  18.]], dtype=float32)
-    >>> bm = num.zeros((4,2,2), dtype=num.bool8)
+    >>> bm = np.zeros((4,2,2), dtype=np.bool8)
     >>> bm[2,...] = 1
     >>> median(arrays, badmasks=bm)
     array([[ 0,  8],
@@ -162,7 +163,7 @@ def iaverage(arrays, output=None, outtype=None, nlow=0, nhigh=0, badmasks=None):
                indicates that a particular pixel is not to be included in the
                average calculation.
 
-    >>> a = num.arange(4)
+    >>> a = np.arange(4)
     >>> a = a.reshape((2,2))
     >>> arrays = [a*16, a*4, a*2, a*8]
     >>> average(arrays)
@@ -174,10 +175,10 @@ def iaverage(arrays, output=None, outtype=None, nlow=0, nhigh=0, badmasks=None):
     >>> average(arrays, nlow=1)
     array([[ 0,  9],
            [18, 28]])
-    >>> average(arrays, outtype=num.float32)
+    >>> average(arrays, outtype=np.float32)
     array([[  0. ,   7.5],
            [ 15. ,  22.5]], dtype=float32)
-    >>> bm = num.zeros((4,2,2), dtype=num.bool8)
+    >>> bm = np.zeros((4,2,2), dtype=np.bool8)
     >>> bm[2,...] = 1
     >>> average(arrays, badmasks=bm)
     array([[ 0,  9],
@@ -188,6 +189,7 @@ def iaverage(arrays, output=None, outtype=None, nlow=0, nhigh=0, badmasks=None):
 
     """
     return _combine_f("iaverage", arrays, output, outtype, nlow, nhigh, badmasks)
+
 
 def average(arrays, output=None, outtype=None, nlow=0, nhigh=0, badmasks=None):
     """average() nominally computes the average pixel value for a stack of
@@ -213,7 +215,7 @@ def average(arrays, output=None, outtype=None, nlow=0, nhigh=0, badmasks=None):
                indicates that a particular pixel is not to be included in the
                average calculation.
 
-    >>> a = num.arange(4)
+    >>> a = np.arange(4)
     >>> a = a.reshape((2,2))
     >>> arrays = [a*16, a*4, a*2, a*8]
     >>> average(arrays)
@@ -225,10 +227,10 @@ def average(arrays, output=None, outtype=None, nlow=0, nhigh=0, badmasks=None):
     >>> average(arrays, nlow=1)
     array([[ 0,  9],
            [18, 28]])
-    >>> average(arrays, outtype=num.float32)
+    >>> average(arrays, outtype=np.float32)
     array([[  0. ,   7.5],
            [ 15. ,  22.5]], dtype=float32)
-    >>> bm = num.zeros((4,2,2), dtype=num.bool8)
+    >>> bm = np.zeros((4,2,2), dtype=np.bool8)
     >>> bm[2,...] = 1
     >>> average(arrays, badmasks=bm)
     array([[ 0,  9],
@@ -241,6 +243,7 @@ def average(arrays, output=None, outtype=None, nlow=0, nhigh=0, badmasks=None):
 
     return _combine_f("average", arrays, output, outtype, nlow, nhigh,
                       badmasks)
+
 
 def minimum(arrays, output=None, outtype=None, nlow=0, nhigh=0, badmasks=None):
     """minimum() nominally computes the minimum pixel value for a stack of
@@ -266,7 +269,7 @@ def minimum(arrays, output=None, outtype=None, nlow=0, nhigh=0, badmasks=None):
                indicates that a particular pixel is not to be included in the
                minimum calculation.
 
-    >>> a = num.arange(4)
+    >>> a = np.arange(4)
     >>> a = a.reshape((2,2))
     >>> arrays = [a*16, a*4, a*2, a*8]
     >>> minimum(arrays)
@@ -278,10 +281,10 @@ def minimum(arrays, output=None, outtype=None, nlow=0, nhigh=0, badmasks=None):
     >>> minimum(arrays, nlow=1)
     array([[ 0,  4],
            [ 8, 12]])
-    >>> minimum(arrays, outtype=num.float32)
+    >>> minimum(arrays, outtype=np.float32)
     array([[ 0.,  2.],
            [ 4.,  6.]], dtype=float32)
-    >>> bm = num.zeros((4,2,2), dtype=num.bool8)
+    >>> bm = np.zeros((4,2,2), dtype=np.bool8)
     >>> bm[2,...] = 1
     >>> minimum(arrays, badmasks=bm)
     array([[ 0,  4],
@@ -302,9 +305,9 @@ def threshhold(arrays, low=None, high=None, outputs=None):
     boolean value is true where each of the arrays values
     is < the low or >= the high threshholds.
 
-    >>> a=num.arange(100)
+    >>> a=np.arange(100)
     >>> a=a.reshape((10,10))
-    >>> (threshhold(a, 1, 50)).astype(num.int8)
+    >>> (threshhold(a, 1, 50)).astype(np.int8)
     array([[1, 0, 0, 0, 0, 0, 0, 0, 0, 0],
            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
@@ -315,7 +318,7 @@ def threshhold(arrays, low=None, high=None, outputs=None):
            [1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
            [1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
            [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]], dtype=int8)
-    >>> (threshhold([ range(10)]*10, 3, 7)).astype(num.int8)
+    >>> (threshhold([ range(10)]*10, 3, 7)).astype(np.int8)
     array([[1, 1, 1, 0, 0, 0, 0, 1, 1, 1],
            [1, 1, 1, 0, 0, 0, 0, 1, 1, 1],
            [1, 1, 1, 0, 0, 0, 0, 1, 1, 1],
@@ -326,7 +329,7 @@ def threshhold(arrays, low=None, high=None, outputs=None):
            [1, 1, 1, 0, 0, 0, 0, 1, 1, 1],
            [1, 1, 1, 0, 0, 0, 0, 1, 1, 1],
            [1, 1, 1, 0, 0, 0, 0, 1, 1, 1]], dtype=int8)
-    >>> (threshhold(a, high=50)).astype(num.int8)
+    >>> (threshhold(a, high=50)).astype(np.int8)
     array([[0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
@@ -337,7 +340,7 @@ def threshhold(arrays, low=None, high=None, outputs=None):
            [1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
            [1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
            [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]], dtype=int8)
-    >>> (threshhold(a, low=50)).astype(num.int8)
+    >>> (threshhold(a, low=50)).astype(np.int8)
     array([[1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
            [1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
            [1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
@@ -350,45 +353,44 @@ def threshhold(arrays, low=None, high=None, outputs=None):
            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]], dtype=int8)
 
     """
+    arrays = np.asarray(arrays)
 
-    if not isinstance(arrays[0],  num.ndarray):
-        return threshhold( num.asarray(arrays), low, high, outputs)
+    if high is None and low is None:
+        return np.zeros_like(arrays, dtype=np.bool)
 
     if outputs is None:
-        outs = num.zeros(shape=(len(arrays),)+arrays[0].shape,
-                         dtype=num.bool8)
+        outputs = np.empty_like(arrays, dtype=np.bool)
+
+    if high is None:
+        for k in range(arrays.shape[0]):
+            np.less(arrays[k], low, outputs[k])
     else:
-        outs = outputs
-
-    for i in range(len(arrays)):
-        a, out = arrays[i], outs[i]
-        out[:] = 0
-
-        if high is not None:
-            num.greater_equal(a, high, out)
-            if low is not None:
-                num.logical_or(out, a < low, out)
+        if low is None:
+            for k in range(arrays.shape[0]):
+                np.greater_equal(arrays[k], high, outputs[k])
         else:
-            if low is not None:
-                num.less(a, low, out)
+            for k in range(arrays.shape[0]):
+                arr = arrays[k]
+                out = outputs[k]
+                np.greater_equal(arr, high, out)
+                np.logical_or(out, arr < low, out)
 
-    if outputs is None:
-        return outs
+    return outputs
 
 
 def _bench():
     """time a 10**6 element median"""
     import time
-    a = num.arange(10**6)
+    a = np.arange(10**6)
     a = a.reshape((1000, 1000))
     arrays = [a*2, a*64, a*16, a*8]
     t0 = time.clock()
     median(arrays)
     print("maskless:", time.clock()-t0)
 
-    a = num.arange(10**6)
+    a = np.arange(10**6)
     a = a.reshape((1000, 1000))
     arrays = [a*2, a*64, a*16, a*8]
     t0 = time.clock()
-    median(arrays, badmasks=num.zeros((1000,1000), dtype=num.bool8))
+    median(arrays, badmasks=np.zeros((1000,1000), dtype=np.bool8))
     print("masked:", time.clock()-t0)

--- a/stsci/image/numcombine.py
+++ b/stsci/image/numcombine.py
@@ -121,8 +121,8 @@ class numCombine(object):
         lower = None                # Throw out values < lower in a median calculation
         ):
         warnings.warn("The 'numCombine' class is deprecated and may be removed"
-                      " in a future version. Use 'num_combine()' instead of "
-                      "'numCombine' class", DeprecationWarning)
+                      " in a future version. Use 'num_combine()' instead.",
+                      DeprecationWarning)
         # keep code with new variable name
         arrMaskList = numarrayMaskList
 

--- a/stsci/image/numcombine.py
+++ b/stsci/image/numcombine.py
@@ -121,7 +121,8 @@ class numCombine(object):
         lower = None                # Throw out values < lower in a median calculation
         ):
         warnings.warn("The 'numCombine' class is deprecated and may be removed"
-                      " in a future version. Use ", DeprecationWarning)
+                      " in a future version. Use 'num_combine()' instead of "
+                      "'numCombine' class", DeprecationWarning)
         # keep code with new variable name
         arrMaskList = numarrayMaskList
 

--- a/stsci/image/numcombine.py
+++ b/stsci/image/numcombine.py
@@ -35,42 +35,56 @@
 #
 #      Version 0.5.1: changed variable names from numarray* to arr* and removed
 #                     use of numerixenv to reflect sole support for numpy
-
-# Import necessary modules
-from __future__ import division, print_function
-
-import numpy as n
+#      Version 0.6.0: Modernized code: replacing numCombine class with
+#                     num_combine function.
+from __future__ import (absolute_import, division, unicode_literals,
+                        print_function)
+import warnings
+import numpy as np
 import stsci.image as image
 
-# Version number
-__version__ = '0.5.1'
+__version__ = '0.6.0'
 
 
 class numCombine(object):
-    """ A lite version of the imcombine IRAF task
+    """ **DEPRECATED.** A lite version of the imcombine IRAF task
+
+    .. warn::
+        This class has been deprecated since version 0.6.0 and it will be
+        removed in a future release. Use `num_combine` instead of this
+        class.
 
     Parameters
     ----------
     arrObjectList : list of ndarray
-        A sequence of inputs arrays, which are nominally a stack of identically shaped images.
+        A sequence of inputs arrays, which are nominally a stack of identically
+        shaped images.
+
     numarrayMaskList : list of ndarray
-        A sequence of mask arrays to use for masking out 'bad' pixels from the combination
-        The ndarray should be a numpy array, despite the variable name.
+        A sequence of mask arrays to use for masking out 'bad' pixels from the
+        combination. The ndarray should be a numpy array, despite the
+        variable name.
+
     combinationType : {'median','imedian','iaverage','mean','sum','minimum'}
-        Type of operation should be used to combine the images
-        The 'imedian' and 'iaverage' types ignore pixels which have been flagged
-        as bad in all input arrays and returns the value from the last image in
-        the stack for that pixel.
+        Type of operation should be used to combine the images.
+        The 'imedian' and 'iaverage' types ignore pixels which have been
+        flagged as bad in all input arrays and returns the value from the
+        last image in the stack for that pixel.
+
     nlow : int [Default: 0]
-        Number of low pixels to throw out of the median calculation
+        Number of low pixels to throw out of the median calculation.
+
     nhigh : int [Default: 0]
-        Number of high pixels to throw out of the median calculation
+        Number of high pixels to throw out of the median calculation.
+
     nkeep : int [Default: 1]
-        Minimun number of pixels to keep for a valid computation
+        Minimun number of pixels to keep for a valid computation.
+
     upper : float, optional
-        Throw out values >= to upper in a median calculation
+        Throw out values >= to upper in a median calculation.
+
     lower: float, optional
-        Throw out values < lower in a median calculation
+        Throw out values < lower in a median calculation.
 
     Returns
     -------
@@ -96,7 +110,6 @@ class numCombine(object):
            [ 1.01666665,  1.01666665,  1.01666665,  1.01666665,  1.01666665]], dtype=float32)
 
     """
-
     def __init__(self,
         arrObjectList,         # Specifies a sequence of inputs arrays, which are nominally a stack of identically shaped images.
         numarrayMaskList = None,    #
@@ -107,17 +120,18 @@ class numCombine(object):
         upper = None,               # Throw out values >= to upper in a median calculation
         lower = None                # Throw out values < lower in a median calculation
         ):
-
+        warnings.warn("The 'numCombine' class is deprecated and may be removed"
+                      " in a future version. Use ", DeprecationWarning)
         # keep code with new variable name
         arrMaskList = numarrayMaskList
 
         # Convert the input arrays to the type of array used by the numerix layer
         for i in range(len(arrObjectList)):
-            arrObjectList[i] = n.asarray(arrObjectList[i])
+            arrObjectList[i] = np.asarray(arrObjectList[i])
 
         if arrMaskList is not None:
             for i in range(len(arrMaskList)):
-                arrMaskList[i] = n.asarray(arrMaskList[i])
+                arrMaskList[i] = np.asarray(arrMaskList[i])
 
         # define variables
         self.__arrObjectList = arrObjectList
@@ -138,7 +152,7 @@ class numCombine(object):
             raise ValueError("Rejecting more pixels than specified by the nkeep parameter!")
 
         # Create output numarray object
-        self.combArrObj = n.zeros(self.__arrObjectList[0].shape,dtype=self.__arrObjectList[0].dtype )
+        self.combArrObj = np.zeros(self.__arrObjectList[0].shape,dtype=self.__arrObjectList[0].dtype )
 
         # Generate masks if necessary and combine them with the input masks (if any).
         self._createMaskList()
@@ -179,7 +193,7 @@ class numCombine(object):
             self.__masks = self.__arrMaskList
         else:
             for mask in range(len(self.__arrMaskList)):
-                self.__masks.append(n.logical_or(__tmpMaskList[mask],self.__arrMaskList[mask]))
+                self.__masks.append(np.logical_or(__tmpMaskList[mask],self.__arrMaskList[mask]))
         del (__tmpMaskList)
         return None
 
@@ -211,12 +225,13 @@ class numCombine(object):
         # Sum the images in the input list
         #print "* Creating a sum array..."
         for imgobj in self.__arrObjectList:
-            n.add(self.combArrObj,imgobj,self.combArrObj)
+            np.add(self.combArrObj,imgobj,self.combArrObj)
     def _minimum(self):
         # Nominally computes the minimum pixel value for a stack of
         # identically shaped images
         try:
-            # Try using the numarray.images.combine function "minimum" that is available as part of numarray version 1.3
+            # Try using the numarray.images.combine function "minimum" that
+            # is available as part of numarray version 1.3
             image.minimum(self.__arrObjectList,self.combArrObj,nlow=self.__nlow,nhigh=self.__nhigh,badmasks=self.__masks)
         except:
             # If numarray version 1.3 is not installed so that the "minimum" function is not available.  We will create our own minimum images but no clipping
@@ -248,7 +263,7 @@ class numCombine(object):
 
                 # For each image, set pixels masked as "bad" to the "super-maximum" value.
                 for imgobj in range(len(self.__arrObjectList)):
-                    tmp = n.where(self.__arrMaskList[imgobj] == 1,_maxValue+1,self.__arrObjectList[imgobj])
+                    tmp = np.where(self.__arrMaskList[imgobj] == 1,_maxValue+1,self.__arrObjectList[imgobj])
                     tmpList.append(tmp)
             else:
                 for imgobj in range(len(self.__arrObjectList)):
@@ -261,12 +276,119 @@ class numCombine(object):
             # If we have been given masks we need to reset the mask values to 0 in the image
             if (self.__arrMaskList != None):
                 # Reset any pixl at _maxValue + 1 to 0.
-                self.combArrObj = n.where(__maskSum == self.__numObjs, 0, self.combArrObj)
+                self.combArrObj = np.where(__maskSum == self.__numObjs, 0, self.combArrObj)
 
 
     def __sumImages(self,arrObjectList):
         """ Sum a list of numarray objects. """
-        __sum = n.zeros(arrObjectList[0].shape,dtype=arrObjectList[0].dtype)
+        __sum = np.zeros(arrObjectList[0].shape,dtype=arrObjectList[0].dtype)
         for imgobj in arrObjectList:
             __sum += imgobj
         return __sum
+
+
+def num_combine(data, masks=None, combination_type="median",
+                nlow=0, nhigh=0, upper=None, lower=None):
+    """ A lite version of the imcombine IRAF task
+
+    Parameters
+    ----------
+    data : list of 2D numpy.ndarray or a 3D numpy.ndarray
+        A sequence of inputs arrays, which are nominally a stack of identically
+        shaped images.
+
+    masks : list of 2D numpy.ndarray or a 3D numpy.ndarray
+        A sequence of mask arrays to use for masking out 'bad' pixels from the
+        combination. The ndarray should be a numpy array, despite the variable
+        name.
+
+    combinationType : {'median', 'imedian', 'iaverage', 'mean', 'sum', 'minimum'}
+        Type of operation should be used to combine the images.
+        The 'imedian' and 'iaverage' types ignore pixels which have been
+        flagged as bad in all input arrays and returns the value from the last
+        image in the stack for that pixel.
+
+    nlow : int, optional
+        Number of low pixels to throw out of the median calculation.
+
+    nhigh : int, optional
+        Number of high pixels to throw out of the median calculation.
+
+    upper : float, optional
+        Throw out values >= to upper in a median calculation.
+
+    lower : float, optional
+        Throw out values < lower in a median calculation.
+
+    Returns
+    -------
+    comb_arr : numpy.ndarray
+        Combined output array.
+
+    Examples
+    --------
+    This function can be used to create a median image from a stack of images
+    with the following commands:
+
+    >>> import numpy as np
+    >>> from stsci.image import numcombine as nc
+    >>> a = np.ones([5,5],np.float32)
+    >>> b = a - 0.05
+    >>> c = a + 0.1
+    >>> result = nc.numcombine([a,b,c],combinationType='mean')
+    >>> result
+    array([[ 1.01666665,  1.01666665,  1.01666665,  1.01666665,  1.01666665],
+           [ 1.01666665,  1.01666665,  1.01666665,  1.01666665,  1.01666665],
+           [ 1.01666665,  1.01666665,  1.01666665,  1.01666665,  1.01666665],
+           [ 1.01666665,  1.01666665,  1.01666665,  1.01666665,  1.01666665],
+           [ 1.01666665,  1.01666665,  1.01666665,  1.01666665,  1.01666665]],
+           dtype=float32)
+
+    """
+    data = np.asarray(data)
+    if masks is not None:
+        masks = np.asarray(masks)
+
+    # Simple sanity check to make sure that the min/max clipping doesn't throw
+    # out all of the pixels.
+    if data.shape[0] - nlow - nhigh < 1:
+        raise ValueError("Rejecting all pixels due to large 'nval' and/or "
+                         "'nhigh'!")
+
+    # Create output numarray object
+    comb_arr = np.empty_like(data[0])
+
+    # Create the threshold masks if necessary and combine them with the
+    # input masks (if any).
+    if lower is not None or upper is not None:
+        thmasks = image.threshhold(data, low=lower, high=upper)
+        if masks is None:
+            masks = thmasks
+        else:
+            masks = np.logical_or(masks, thmasks)
+
+    # Combine the input images.
+    combination_type = combination_type.lower()
+
+    if combination_type == 'median':
+        image.median(data, comb_arr, comb_arr.dtype, nlow=nlow, nhigh=nhigh,
+                     badmasks=masks)
+    elif combination_type == 'imedian':
+        image.imedian(data, comb_arr, comb_arr.dtype, nlow=nlow, nhigh=nhigh,
+                      badmasks=masks)
+    elif combination_type in ['iaverage', 'imean']:
+        image.iaverage(data, comb_arr, comb_arr.dtype, nlow=nlow, nhigh=nhigh,
+                       badmasks=masks)
+    elif combination_type == 'mean':
+        image.average(data, comb_arr, comb_arr.dtype, nlow=nlow, nhigh=nhigh,
+                      badmasks=masks)
+    elif combination_type == 'sum':
+        np.sum(data, axis=0, out=comb_arr)
+    elif combination_type == 'minimum':
+        image.minimum(data, comb_arr, comb_arr.dtype, nlow=nlow, nhigh=nhigh,
+                      badmasks=masks)
+    else:
+        comb_arr.fill(0)
+        print("Combination type not supported!!!")
+
+    return comb_arr


### PR DESCRIPTION
Outdated code in this package was generating numerous deprecation warnings in the drizzlepac related to comparisons with `None` instead of `is None`. I also rewrote/modernized `numCombine` and `threshhold()` using a cleaner, more easy to maintain code, and possibly slightly/marginally more performant (due to elimination of a couple of unnecessary operations).