### PR TITLE
Remove stsci.tools.tester dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 __pycache__
+.pytest_cache
 .eggs
 build
 dist

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+__pycache__
+.eggs
+build
+dist
+*.egg-info
+version.py
+*.so

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,8 +15,8 @@ classifier =
     Topic :: Software Development :: Libraries :: Python Modules
 requires-python = >=2.5
 requires-dist =
-    numpy (>=1.5.1)
-    scipy (>=0.14)
+    numpy
+    scipy
 
 [files]
 packages =

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,30 +7,26 @@ summary = Image array manipulation functions
 description = Formerly included in SciPy as scipy.stsci.image
 home-page = http://www.stsci.edu/resources/software_hardware/stsci_python
 classifier =
-	Intended Audience :: Science/Research
-	License :: OSI Approved :: BSD License
-	Operating System :: OS Independent
-	Programming Language :: Python
-	Topic :: Scientific/Engineering :: Astronomy
-	Topic :: Software Development :: Libraries :: Python Modules
+    Intended Audience :: Science/Research
+    License :: OSI Approved :: BSD License
+    Operating System :: OS Independent
+    Programming Language :: Python
+    Topic :: Scientific/Engineering :: Astronomy
+    Topic :: Software Development :: Libraries :: Python Modules
 requires-python = >=2.5
 requires-dist =
-	stsci.tools
-	numpy (>=1.5.1)
-        scipy (>=0.14)
+    numpy (>=1.5.1)
+    scipy (>=0.14)
 
 [files]
 packages =
-	stsci
-	stsci.image
-	stsci.image.test
-package_data =
-	stsci.image.test = data/*.fits
+    stsci
+    stsci.image
 
 [extension=stsci.image._combine]
 sources = src/_combinemodule.c
 define_macros =
-	NUMPY = 1
+    NUMPY = 1
 include_dirs = numpy
 extra_compile_args = -Wno-unused-function
 
@@ -39,7 +35,7 @@ pre-hook.numpy-extension-hook = stsci.distutils.hooks.numpy_extension_hook
 
 [global]
 setup_hooks =
-	stsci.distutils.hooks.use_packages_root
-	stsci.distutils.hooks.tag_svn_revision
-	stsci.distutils.hooks.version_setup_hook
+    stsci.distutils.hooks.use_packages_root
+    stsci.distutils.hooks.tag_svn_revision
+    stsci.distutils.hooks.version_setup_hook
 

--- a/stsci/image/__init__.py
+++ b/stsci/image/__init__.py
@@ -4,10 +4,3 @@ from ._image import *
 from .combine import *
 
 from .version import *
-
-try:
-    import stsci.tools.tester
-    def test(*args,**kwds):
-        stsci.tools.tester.test(modname=__name__, *args, **kwds)
-except ImportError:
-    pass


### PR DESCRIPTION
The `stsci.tools.tester` module was removed [here](https://github.com/spacetelescope/stsci.tools/pull/76), so it should not be referenced in this package.

Also, this was the only reference to `stsci.tools` in this package, so it is no longer a dependency.  Which is my real motivation for this PR - removing the `stsci.tools` dependency from this package.