### PR TITLE
Remove -Wno-unused-function argument

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,6 @@ sources = src/_combinemodule.c
 define_macros =
     NUMPY = 1
 include_dirs = numpy
-extra_compile_args = -Wno-unused-function
 
 [build_ext]
 pre-hook.numpy-extension-hook = stsci.distutils.hooks.numpy_extension_hook


### PR DESCRIPTION
It's just a warning and the argument in question prevents Microsoft CL from compiling.