### PR TITLE
Bump version -> 2.3.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = stsci.image
-version = 2.3.0
+version = 2.3.1
 author = Todd Miller
 author-email = help@stsci.edu
 summary = Image array manipulation functions


### PR DESCRIPTION
* Removes `stsci.tools.tester` dependency
* Removes GCC-only argument