### PR TITLE
Remove nose test dependency

### DIFF
--- a/src/_combinemodule.c
+++ b/src/_combinemodule.c
@@ -240,7 +240,7 @@ _Py_combine(PyObject *obj, PyObject *args, PyObject *kw)
             return NULL;
         }
         arr[i] = (PyArrayObject *) PyArray_FROM_OTF(a, NPY_FLOAT64,
-                                                    NPY_IN_ARRAY);
+                                                    NPY_ARRAY_INOUT_ARRAY2);
         if (!arr[i]) {
             return NULL;
         }
@@ -260,7 +260,7 @@ _Py_combine(PyObject *obj, PyObject *args, PyObject *kw)
     }
 
     toutput = (PyArrayObject *) PyArray_FROM_OTF(output, NPY_FLOAT64,
-                                                 NPY_INOUT_ARRAY);
+                                                 NPY_ARRAY_INOUT_ARRAY2);
     if (!toutput) {
         return NULL;
     }
@@ -283,11 +283,14 @@ _Py_combine(PyObject *obj, PyObject *args, PyObject *kw)
     }
 
     for(i=0; i<narrays; i++) {
+        PyArray_ResolveWritebackIfCopy(arr[i]);
         Py_DECREF(arr[i]);
         if (badmasks != Py_None) {
+            PyArray_ResolveWritebackIfCopy(bmk[i]);
             Py_DECREF(bmk[i]);
         }
     }
+    PyArray_ResolveWritebackIfCopy(toutput);
     Py_DECREF(toutput);
 
     Py_INCREF(Py_None);

--- a/stsci/image/combine.py
+++ b/stsci/image/combine.py
@@ -60,25 +60,20 @@ def imedian(arrays, output=None, outtype=None, nlow=0, nhigh=0, badmasks=None):
     >>> median(arrays)
     array([[ 0,  6],
            [12, 18]])
-
     >>> median(arrays, nhigh=1)
     array([[ 0,  4],
            [ 8, 12]])
-
     >>> median(arrays, nlow=1)
     array([[ 0,  8],
            [16, 24]])
-
     >>> median(arrays, outtype=np.float32)
-    array([[  0.,   6.],
-           [ 12.,  18.]], dtype=float32)
-
+    array([[ 0.,  6.],
+           [12., 18.]], dtype=float32)
     >>> bm = np.zeros((4,2,2), dtype=np.bool8)
     >>> bm[2,...] = 1
     >>> median(arrays, badmasks=bm)
     array([[ 0,  8],
            [16, 24]])
-
     >>> median(arrays, badmasks=threshhold(arrays, high=25))
     array([[ 0,  6],
            [ 8, 12]])
@@ -123,8 +118,8 @@ def median(arrays, output=None, outtype=None, nlow=0, nhigh=0, badmasks=None):
     array([[ 0,  8],
            [16, 24]])
     >>> median(arrays, outtype=np.float32)
-    array([[  0.,   6.],
-           [ 12.,  18.]], dtype=float32)
+    array([[ 0.,  6.],
+           [12., 18.]], dtype=float32)
     >>> bm = np.zeros((4,2,2), dtype=np.bool8)
     >>> bm[2,...] = 1
     >>> median(arrays, badmasks=bm)
@@ -176,8 +171,8 @@ def iaverage(arrays, output=None, outtype=None, nlow=0, nhigh=0, badmasks=None):
     array([[ 0,  9],
            [18, 28]])
     >>> average(arrays, outtype=np.float32)
-    array([[  0. ,   7.5],
-           [ 15. ,  22.5]], dtype=float32)
+    array([[ 0. ,  7.5],
+           [15. , 22.5]], dtype=float32)
     >>> bm = np.zeros((4,2,2), dtype=np.bool8)
     >>> bm[2,...] = 1
     >>> average(arrays, badmasks=bm)
@@ -228,8 +223,8 @@ def average(arrays, output=None, outtype=None, nlow=0, nhigh=0, badmasks=None):
     array([[ 0,  9],
            [18, 28]])
     >>> average(arrays, outtype=np.float32)
-    array([[  0. ,   7.5],
-           [ 15. ,  22.5]], dtype=float32)
+    array([[ 0. ,  7.5],
+           [15. , 22.5]], dtype=float32)
     >>> bm = np.zeros((4,2,2), dtype=np.bool8)
     >>> bm[2,...] = 1
     >>> average(arrays, badmasks=bm)
@@ -282,8 +277,8 @@ def minimum(arrays, output=None, outtype=None, nlow=0, nhigh=0, badmasks=None):
     array([[ 0,  4],
            [ 8, 12]])
     >>> minimum(arrays, outtype=np.float32)
-    array([[ 0.,  2.],
-           [ 4.,  6.]], dtype=float32)
+    array([[0., 2.],
+           [4., 6.]], dtype=float32)
     >>> bm = np.zeros((4,2,2), dtype=np.bool8)
     >>> bm[2,...] = 1
     >>> minimum(arrays, badmasks=bm)

--- a/stsci/image/numcombine.py
+++ b/stsci/image/numcombine.py
@@ -90,25 +90,6 @@ class numCombine(object):
     -------
     combArrObj : ndarray
         The attribute '.combArrObj' holds the combined output array.
-
-    Examples
-    --------
-    This class can be used to create a median image from a stack of images
-    with the following commands:
-
-    >>> import numpy as np
-    >>> from stsci.image import numcombine as nc
-    >>> a = np.ones([5,5],np.float32)
-    >>> b = a - 0.05
-    >>> c = a + 0.1
-    >>> result = nc.numCombine([a,b,c],combinationType='mean')
-    >>> result.combArrObj
-    array([[ 1.01666665,  1.01666665,  1.01666665,  1.01666665,  1.01666665],
-           [ 1.01666665,  1.01666665,  1.01666665,  1.01666665,  1.01666665],
-           [ 1.01666665,  1.01666665,  1.01666665,  1.01666665,  1.01666665],
-           [ 1.01666665,  1.01666665,  1.01666665,  1.01666665,  1.01666665],
-           [ 1.01666665,  1.01666665,  1.01666665,  1.01666665,  1.01666665]], dtype=float32)
-
     """
     def __init__(self,
         arrObjectList,         # Specifies a sequence of inputs arrays, which are nominally a stack of identically shaped images.
@@ -336,15 +317,13 @@ def num_combine(data, masks=None, combination_type="median",
     >>> a = np.ones([5,5],np.float32)
     >>> b = a - 0.05
     >>> c = a + 0.1
-    >>> result = nc.numcombine([a,b,c],combinationType='mean')
+    >>> result = nc.num_combine([a, b, c], combination_type='mean')
     >>> result
-    array([[ 1.01666665,  1.01666665,  1.01666665,  1.01666665,  1.01666665],
-           [ 1.01666665,  1.01666665,  1.01666665,  1.01666665,  1.01666665],
-           [ 1.01666665,  1.01666665,  1.01666665,  1.01666665,  1.01666665],
-           [ 1.01666665,  1.01666665,  1.01666665,  1.01666665,  1.01666665],
-           [ 1.01666665,  1.01666665,  1.01666665,  1.01666665,  1.01666665]],
-           dtype=float32)
-
+    array([[1.0166667, 1.0166667, 1.0166667, 1.0166667, 1.0166667],
+           [1.0166667, 1.0166667, 1.0166667, 1.0166667, 1.0166667],
+           [1.0166667, 1.0166667, 1.0166667, 1.0166667, 1.0166667],
+           [1.0166667, 1.0166667, 1.0166667, 1.0166667, 1.0166667],
+           [1.0166667, 1.0166667, 1.0166667, 1.0166667, 1.0166667]], dtype=float32)
     """
     data = np.asarray(data)
     if masks is not None:

--- a/stsci/image/test/test_average.py
+++ b/stsci/image/test/test_average.py
@@ -1,7 +1,4 @@
-#!/usr/bin/env python
 import numpy as np
-import nose
-from nose.tools import *
 from stsci.image import combine
 
 
@@ -41,28 +38,28 @@ def test_average1():
     result = combine.average(arrays)
     expected = np.array([[ 0,  7],
                          [15, 22]])
-    assert_true((result == expected).all())
+    assert (result == expected).all()
 
 
 def test_average2():
     result = combine.average(arrays, nhigh=1)
     expected = np.array([[ 0,  4],
                          [ 9, 14]])
-    assert_true((result == expected).all())
+    assert (result == expected).all()
 
 
 def test_average3():
     result = combine.average(arrays, nlow=1)
     expected = np.array([[ 0,  9],
                          [18, 28]])
-    assert_true((result == expected).all())
+    assert (result == expected).all()
 
 
 def test_average4():
     result = combine.average(arrays, outtype=np.float32)
     expected = np.array([[  0. ,   7.5],
                          [ 15. ,  22.5]], dtype=np.float32)
-    assert_true((result == expected).all())
+    assert (result == expected).all()
 
 
 def test_average5():
@@ -71,7 +68,7 @@ def test_average5():
     result = combine.average(arrays, badmasks=bm)
     expected = np.array([[ 0,  9],
                          [18, 28]])
-    assert_true((result == expected).all())
+    assert (result == expected).all()
 
 
 def test_average6():
@@ -79,5 +76,5 @@ def test_average6():
                              badmasks=combine.threshhold(arrays, high=25))
     expected = np.array([[ 0,  7],
                          [ 9, 14]])
-    assert_true((result == expected).all())
+    assert (result == expected).all()
 

--- a/stsci/image/test/test_median.py
+++ b/stsci/image/test/test_median.py
@@ -1,7 +1,4 @@
-#!/usr/bin/env python
 import numpy as np
-import nose
-from nose.tools import *
 from stsci.image import combine
 
 
@@ -41,28 +38,28 @@ def test_median1():
     result = combine.median(arrays)
     expected = np.array([[ 0,  6],
                          [12, 18]])
-    assert_true((result == expected).all())
+    assert (result == expected).all()
 
 
 def test_median2():
     result = combine.median(arrays, nhigh=1)
     expected = np.array([[ 0,  4],
                          [ 8, 12]])
-    assert_true((result == expected).all())
+    assert (result == expected).all()
 
 
 def test_median3():
     result = combine.median(arrays, nlow=1)
     expected = np.array([[ 0,  8],
                          [16, 24]])
-    assert_true((result == expected).all())
+    assert (result == expected).all()
 
 
 def test_median4():
     result = combine.median(arrays, outtype=np.float32)
     expected = np.array([[  0.,   6.],
                          [ 12.,  18.]], dtype=np.float32)
-    assert_true((result == expected).all())
+    assert (result == expected).all()
 
 
 def test_median5():
@@ -71,7 +68,7 @@ def test_median5():
     result = combine.median(arrays, badmasks=bm)
     expected = np.array([[ 0,  8],
                          [16, 24]])
-    assert_true((result == expected).all())
+    assert (result == expected).all()
 
 
 def test_median6():
@@ -79,4 +76,4 @@ def test_median6():
                             badmasks=combine.threshhold(arrays, high=25))
     expected = np.array([[ 0,  6],
                          [ 8, 12]])
-    assert_true((result == expected).all())
+    assert (result == expected).all()

--- a/stsci/image/test/test_minimum.py
+++ b/stsci/image/test/test_minimum.py
@@ -1,8 +1,4 @@
-#!/usr/bin/env python
-
 import numpy as np
-import nose
-from nose.tools import *
 from stsci.image import combine
 
 
@@ -42,28 +38,28 @@ def test_minimum1():
     result = combine.minimum(arrays)
     expected = np.array([[0, 2],
                          [4, 6]])
-    assert_true((result == expected).all())
+    assert (result == expected).all()
 
 
 def test_minimum2():
     result = combine.minimum(arrays, nhigh=1)
     expected = np.array([[0, 2],
                          [4, 6]])
-    assert_true((result == expected).all())
+    assert (result == expected).all()
 
 
 def test_minimum3():
     result = combine.minimum(arrays, nlow=1)
     expected = np.array([[ 0,  4],
                          [ 8, 12]])
-    assert_true((result == expected).all())
+    assert (result == expected).all()
 
 
 def test_minimum4():
     result = combine.minimum(arrays, outtype=np.float32)
     expected = np.array([[ 0.,  2.],
                          [ 4.,  6.]], dtype=np.float32)
-    assert_true((result == expected).all())
+    assert (result == expected).all()
 
 
 def test_minimum5():
@@ -72,7 +68,7 @@ def test_minimum5():
     result = combine.minimum(arrays, badmasks=bm)
     expected = np.array([[ 0,  4],
                          [ 8, 12]])
-    assert_true((result == expected).all())
+    assert (result == expected).all()
 
 
 def test_minimum6():
@@ -80,4 +76,4 @@ def test_minimum6():
                              badmasks=combine.threshhold(arrays, low=10))
     expected = np.array([[ 0, 16],
                          [16, 12]])
-    assert_true((result == expected).all())
+    assert (result == expected).all()

--- a/stsci/image/test/test_threshold.py
+++ b/stsci/image/test/test_threshold.py
@@ -1,8 +1,4 @@
-#!/usr/bin/env python
-
 import numpy as np
-import nose
-from nose.tools import *
 from stsci.image import combine
 
 
@@ -28,7 +24,7 @@ def test_threshhold1():
          [1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
          [1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
          [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]], dtype=np.int8)
-    assert_true((result == expected).all())
+    assert (result == expected).all()
 
 
 def test_threshold2():
@@ -46,7 +42,7 @@ def test_threshold2():
          [1, 1, 1, 0, 0, 0, 0, 1, 1, 1],
          [1, 1, 1, 0, 0, 0, 0, 1, 1, 1],
          [1, 1, 1, 0, 0, 0, 0, 1, 1, 1]], dtype=np.int8)
-    assert_true((result == expected).all())
+    assert (result == expected).all()
 
 
 def test_threshold3():
@@ -64,7 +60,7 @@ def test_threshold3():
          [1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
          [1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
          [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]], dtype=np.int8)
-    assert_true((result == expected).all())
+    assert (result == expected).all()
 
 
 def test_threshold4():
@@ -82,4 +78,4 @@ def test_threshold4():
          [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
          [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
          [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]], dtype=np.int8)
-    assert_true((result == expected).all())
+    assert (result == expected).all()


### PR DESCRIPTION
- Remove `nose` dependency in tests.  Now just use `pytest` at the top level
- Fix Numpy deprecation warnings.

Resolves #7.