### PR TITLE
Fix for ignoring too many values in a pixel

### DIFF
--- a/src/_combinemodule.c
+++ b/src/_combinemodule.c
@@ -55,6 +55,17 @@ _inner_median(int goodpix, int nlow, int nhigh, int ninputs,
 {
     npy_float64 median;
     int midpoint, medianpix = goodpix-nhigh-nlow;
+    if (medianpix <= 0 && goodpix > 0) {
+        /*
+         * nhigh/nlow discarded all the good pixels
+         * reduce them until we have something left
+         */
+        while (nhigh+nlow >= goodpix) {
+            if (nhigh > 0) nhigh = nhigh-1;
+            if (nlow > 0) nlow = nlow-1;
+        }
+        medianpix = goodpix-nhigh-nlow;
+    }
     if (medianpix <= 0) {
         if (ninputs > 0) {
             median = temp[ninputs-1];
@@ -87,9 +98,9 @@ _inner_old_median(int goodpix, int nlow, int nhigh, int ninputs,
         if (medianpix % 2) /* odd */ {
             median = temp[ midpoint + nlow ];
         } else {
-            median = (temp[ midpoint + nlow ] + 
+            median = (temp[ midpoint + nlow ] +
                   temp[ midpoint + nlow - 1 ]) / 2.0;
-        }    
+        }
     }
     return median;
 }


### PR DESCRIPTION
The bug is in the _inner_median function.  Currently it has this code:

    int midpoint, medianpix = goodpix-nhigh-nlow;
    if (medianpix <= 0) {
        if (ninputs > 0) {
            median = temp[ninputs-1];
        } else{
            median = 0;
        }
    } else { ...

If the number of good pixels, goodpix, is less than nhigh+nlow, this rejects all the points and then either returns zero or returns a random (possibly bad) value from the last image in the list.

This change resolves this problem by adding a little logic to reduce the values of nhigh and nlow when necessary to retain some good points.  That shrinks both nhigh and nlow until there is at least one value left (assuming goodpix > 0).

This will produce the same results as before except in the case where nhigh+nlow>=goodpix.  
This fix was provided by R. White based on what they fixed for HLA processing.