### PR TITLE
Use intrinsic int, bool, and float types instead of numpy

### DIFF
--- a/stsci/image/combine.py
+++ b/stsci/image/combine.py
@@ -351,10 +351,10 @@ def threshhold(arrays, low=None, high=None, outputs=None):
     arrays = np.asarray(arrays)
 
     if high is None and low is None:
-        return np.zeros_like(arrays, dtype=np.bool)
+        return np.zeros_like(arrays, dtype=bool)
 
     if outputs is None:
-        outputs = np.empty_like(arrays, dtype=np.bool)
+        outputs = np.empty_like(arrays, dtype=bool)
 
     if high is None:
         for k in range(arrays.shape[0]):


### PR DESCRIPTION
This replaces the deprecated `numpy` global types

```python
np.float, np.bool, np.int
```

with the Python types

```python
float, bool, int
```
 
to avoid (reduce) deprecation warnings.