### PR TITLE
test with development version of Numpy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+
+  # Maintain dependencies for GitHub Actions (main)
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "main"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,12 +27,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/test_devdeps.yml
+++ b/.github/workflows/test_devdeps.yml
@@ -24,12 +24,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/test_devdeps.yml
+++ b/.github/workflows/test_devdeps.yml
@@ -36,10 +36,7 @@ jobs:
       - name: Install stsci.image
         run: |
           python -m pip install --upgrade pip
-          pip install -e .[test]
-
-      - run: pip install "numpy>=2.0.0.dev0" --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
-
+          pip install -e .[test] "numpy>=2.0.0.dev0" --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
       - name: Run tests
         run: |
           pytest

--- a/.github/workflows/test_devdeps.yml
+++ b/.github/workflows/test_devdeps.yml
@@ -1,0 +1,45 @@
+name: test with development versions
+
+on:
+  push:
+    branches:
+      - master
+      - '*.x'
+    tags:
+      - '*'
+  pull_request:
+  schedule:
+    # Weekly Monday 7AM build
+    - cron: "0 7 * * 1"
+
+jobs:
+  test_devdeps:
+    if: (github.repository == 'spacetelescope/stsci.stimage' && (github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'run devdeps tests')))
+    name: test with development versions
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install stsci.image
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[test]
+
+      - run: pip install "numpy>=2.0.0.dev0" --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+
+      - name: Run tests
+        run: |
+          pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ requires = [
     "setuptools >=61.2",
     "setuptools_scm[toml] >=6.2",
     "wheel",
-    "numpy>=2.0.0b1",
+    "numpy>=2.0.0rc1",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ requires = [
     "setuptools >=61.2",
     "setuptools_scm[toml] >=6.2",
     "wheel",
-    "oldest-supported-numpy",
+    "numpy>=2.0.0b1",
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
resolves [SCSB-109](https://jira.stsci.edu/browse/SCSB-109)

this testing infrastructure should reveal issues with newer versions of Numpy (and possibly other packages in the future)

> [!IMPORTANT]
> this PR is looking for a label named `run devdeps tests` (with spaces) in order to trigger the devdeps tests (I can't add labels myself)