### PR TITLE
[SCSB-155] build with Numpy 2.0 release candidate

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,9 @@ name = "stsci.image"
 description = "Image array manipulation functions"
 readme = "README.md"
 requires-python = ">=3.9"
-license = { file = "LICENSE" }
-authors = [{ name = "STScI", email = "help@stsci.edu" }]
+authors = [
+    { name = "STScI", email = "help@stsci.edu" },
+]
 classifiers = [
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: BSD License",
@@ -17,30 +18,35 @@ dependencies = [
     "numpy",
     "scipy",
 ]
-dynamic = ['version']
+dynamic = [
+    "version",
+]
+
+[project.license]
+file = "LICENSE"
 
 [project.optional-dependencies]
 test = [
-    'pytest',
+    "pytest",
 ]
 docs = [
-    'numpydoc',
-    'sphinx',
-    'sphinx-automodapi',
-    'sphinx-rtd-theme',
-    'stsci-rtd-theme',
-    'tomli; python_version <"3.11"',
+    "numpydoc",
+    "sphinx",
+    "sphinx-automodapi",
+    "sphinx-rtd-theme",
+    "stsci-rtd-theme",
+    "tomli; python_version <\"3.11\"",
 ]
 
 [project.urls]
-'repository' = 'https://github.com/spacetelescope/stsci.image'
+repository = "https://github.com/spacetelescope/stsci.image"
 
 [build-system]
 requires = [
     "setuptools >=61.2",
     "setuptools_scm[toml] >=6.2",
     "wheel",
-    "oldest-supported-numpy",
+    "numpy>=2.0.0rc2",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -48,9 +54,13 @@ build-backend = "setuptools.build_meta"
 zip-safe = false
 
 [tool.setuptools.packages.find]
-include = ['stsci']
+include = [
+    "stsci",
+]
 
 [tool.setuptools.package-data]
-"*" = ["LICENSE.txt"]
+"*" = [
+    "LICENSE.txt",
+]
 
 [tool.setuptools_scm]


### PR DESCRIPTION
resolves [SCSB-155](https://jira.stsci.edu/browse/SCSB-155)

Numpy 2.0 is scheduled for release on June 19th. Due to the C ABI updates, Python projects that build C extensions are required to build against Numpy 2.0 in order to use Numpy 2.0 in runtime.
This is backwards-compatible with Numpy versions in runtime as far back as `1.26`

this PR pins `numpy>=2.0.0rc2` in `build-system.requires`
> [!NOTE]
> this PR was generated automatically by ``batchpr`` :robot:
