### PR TITLE
Replaces NPY_IN_ARRAY with NPY_ARRAY_IN_ARRAY

### DIFF
--- a/src/_combinemodule.c
+++ b/src/_combinemodule.c
@@ -262,7 +262,7 @@ _Py_combine(PyObject *obj, PyObject *args, PyObject *kw)
                 return NULL;
             }
             bmk[i] = (PyArrayObject *) PyArray_FROM_OTF(a, NPY_UINT8,
-                                                        NPY_IN_ARRAY);
+                                                        NPY_ARRAY_IN_ARRAY);
             if (!bmk[i]) {
                 return NULL;
             }


### PR DESCRIPTION
This PR addresses the following error produced by NumPy 2.3 (development wheel):

```
      In file included from /tmp/pip-build-env-vkus6am1/overlay/lib/python3.13/site-packages/numpy/_core/include/numpy/arrayobject.h:5,
                       from src/_combinemodule.c:2:
      src/_combinemodule.c: In function ‘_Py_combine’:
      src/_combinemodule.c:265:57: error: ‘NPY_IN_ARRAY’ undeclared (first use in this function)
        265 |                                                         NPY_IN_ARRAY);
            |                                                         ^~~~~~~~~~~~
      /tmp/pip-build-env-vkus6am1/overlay/lib/python3.13/site-packages/numpy/_core/include/numpy/ndarrayobject.h:91:28: note: in definition of macro ‘PyArray_FROM_OTF’
         91 |                         (((flags) & NPY_ARRAY_ENSURECOPY) ? \
            |                            ^~~~~
      src/_combinemodule.c:265:57: note: each undeclared identifier is reported only once for each function it appears in
        265 |                                                         NPY_IN_ARRAY);
            |                                                         ^~~~~~~~~~~~
      /tmp/pip-build-env-vkus6am1/overlay/lib/python3.13/site-packages/numpy/_core/include/numpy/ndarrayobject.h:91:28: note: in definition of macro ‘PyArray_FROM_OTF’
         91 |                         (((flags) & NPY_ARRAY_ENSURECOPY) ? \
            |                            ^~~~~
      src/_combinemodule.c:279:20: warning: comparison of integer expressions of different signedness: ‘int’ and ‘long unsigned int’ [-Wsign-compare]
        279 |     for (i=0,f=0; i<(sizeof(functions)/sizeof(functions[0])); i++)
            |                    ^
      src/_combinemodule.c: At top level:
      src/_combinemodule.c:89:1: warning: ‘_inner_old_median’ defined but not used [-Wunused-function]
         89 | _inner_old_median(int goodpix, int nlow, int nhigh, int ninputs,
            | ^~~~~~~~~~~~~~~~~
```
