### PR TITLE
Use numpy >=2.0 (drop RC version)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ requires = [
     "setuptools >=61.2",
     "setuptools_scm[toml] >=6.2",
     "wheel",
-    "numpy>=2.0.0rc2",
+    "numpy>=2.0",
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
No need to use the `rc` version anymore