### PR TITLE
Fix Python 3.13 build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,8 @@ jobs:
         include:
           - python-version: "3.12"
             numpy-version: "~=1.26.0"
-        python-version: ["3.9", "3.10", "3.11"]
-        numpy-version: ["~=1.23.0", "~=1.26.0", ""]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"
+        numpy-version: ["~=1.23.0", "~=1.26.0", ">=2.0"]
 
     steps:
       - name: Checkout code
@@ -38,9 +38,14 @@ jobs:
 
       - name: Install stsci.image
         run: |
-          python -m pip install --upgrade pip
-          pip install -e .[test] numpy${{ matrix.numpy-version }}
+          set -x
+          python -m pip install --upgrade pip setuptools
+          python -m pip install -e .[test] numpy${{ matrix.numpy-version }}
+
+      - name: Show packages
+        run: |
+          python -m pip list
 
       - name: Run tests
         run: |
-          pytest
+          python -m pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
+        exclude:
           - python-version: "3.12"
-            numpy-version: "~=1.26.0"
+            numpy-version: "~=1.23.0"
+          - python-version: "3.13"
+            numpy-version: "~=1.23.0"
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         numpy-version: ["~=1.23.0", "~=1.26.0", ">=2.0"]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
             numpy-version: "~=1.23.0"
           - python-version: "3.13"
             numpy-version: "~=1.23.0"
+          - python-version: "3.13"
+            numpy-version: "~=1.26.0"
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         numpy-version: ["~=1.23.0", "~=1.26.0", ">=2.0"]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         include:
           - python-version: "3.12"
             numpy-version: "~=1.26.0"
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         numpy-version: ["~=1.23.0", "~=1.26.0", ">=2.0"]
 
     steps:

--- a/.github/workflows/test_devdeps.yml
+++ b/.github/workflows/test_devdeps.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
       - name: Checkout code

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 __pycache__
 build/
 dist/
+stsci/image/version.py

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+#stsci.image

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ requires = [
     "setuptools >=61.2",
     "setuptools_scm[toml] >=6.2",
     "wheel",
-    "numpy>=2.0.0rc2",
+    "numpy>=2.0",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "numpy",
     "scipy",
 ]
-license-files = ["LICENSE"]
+license-files = ["LICENSE.txt"]
 dynamic = [
     "version",
 ]
@@ -52,7 +52,7 @@ zip-safe = false
 
 [tool.setuptools.packages.find]
 include = [
-    "stsci",
+    "stsci/image",
 ]
 
 [tool.setuptools.package-data]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,3 +61,4 @@ include = [
 ]
 
 [tool.setuptools_scm]
+version_file = "stsci/image/version.py"

--- a/stsci/image/__init__.py
+++ b/stsci/image/__init__.py
@@ -1,9 +1,3 @@
-from importlib.metadata import PackageNotFoundError, version
-try:
-    __version__ = version(__name__)
-except PackageNotFoundError:
-    # package is not installed
-    __version__ = 'unknown'
-
+from .version import __version__
 from ._image import *
 from .combine import *


### PR DESCRIPTION
* Adds a blank `README.md` and fixes the name of the license file in `pyproject.toml` to squelch warnings from `setuptools`. (`LICENSE.txt`, not `LICENSE`)
* Fixes the `__version__` import error after generating `version.py` and removing calls to `importlib`. Coercing `setuptools` to use `stsci/image` as the package, instead of the top-level meta-package appears to work, and still imports as `stsci.image`.
* Adds Python 3.13 to the CI and devdeps workflows
* Excludes incompatible Python and Numpy combinations
* Guarantees `numpy>=2.0` is installed during a CI run.